### PR TITLE
Add web start/stop control with log display

### DIFF
--- a/webapp/server.py
+++ b/webapp/server.py
@@ -1,0 +1,67 @@
+import os
+import subprocess
+import threading
+from collections import deque
+from flask import Flask, jsonify, render_template
+
+app = Flask(__name__)
+
+process = None
+log_lines = deque(maxlen=200)
+log_lock = threading.Lock()
+
+
+def _read_output(pipe):
+    for line in iter(pipe.readline, ''):
+        with log_lock:
+            log_lines.append(line.rstrip())
+    pipe.close()
+
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+
+@app.route('/start', methods=['POST'])
+def start_airband():
+    global process
+    if process and process.poll() is None:
+        return jsonify({'status': 'already_running'})
+
+    cmd = ['rtl_airband', '-f', '-e', '-c', 'airband.conf']
+    cwd = os.path.dirname(os.path.abspath(__file__))
+    process = subprocess.Popen(
+        cmd,
+        cwd=cwd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+    threading.Thread(target=_read_output, args=(process.stdout,), daemon=True).start()
+    return jsonify({'status': 'started'})
+
+
+@app.route('/stop', methods=['POST'])
+def stop_airband():
+    global process
+    if process and process.poll() is None:
+        process.terminate()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+        return jsonify({'status': 'stopped'})
+    return jsonify({'status': 'not_running'})
+
+
+@app.route('/logs')
+def get_logs():
+    with log_lock:
+        lines = list(log_lines)
+    return jsonify({'lines': lines})
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>RTL Airband Control</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        #logs { border: 1px solid #ccc; height: 300px; overflow-y: scroll; background: #f9f9f9; padding: 10px; white-space: pre-wrap; }
+        button { margin-right: 10px; }
+    </style>
+</head>
+<body>
+    <h1>RTL Airband Control</h1>
+    <button id="startBtn">Start</button>
+    <button id="stopBtn">Stop</button>
+    <h2>Logs</h2>
+    <div id="logs"></div>
+
+    <script>
+        const logsDiv = document.getElementById('logs');
+        document.getElementById('startBtn').addEventListener('click', () => {
+            fetch('/start', {method: 'POST'});
+        });
+        document.getElementById('stopBtn').addEventListener('click', () => {
+            fetch('/stop', {method: 'POST'});
+        });
+        async function updateLogs(){
+            const res = await fetch('/logs');
+            const data = await res.json();
+            logsDiv.textContent = data.lines.join('\n');
+            logsDiv.scrollTop = logsDiv.scrollHeight;
+        }
+        setInterval(updateLogs, 1000);
+        updateLogs();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add Flask server to manage rtl_airband as a background process with start, stop, and log retrieval endpoints.
- Create simple web UI with Start/Stop buttons and a live-updating logs section on the main page.

## Testing
- `python -m py_compile webapp/server.py`
- `cmake -S . -B build` *(fails: Failed to detect RTL_AIRBAND_VERSION)*

------
https://chatgpt.com/codex/tasks/task_b_68abbc374d5c832eb638ca4083b4564a